### PR TITLE
Fix: apply tags filter in getMechanicsContentData second fallback

### DIFF
--- a/src/services/content.service.ts
+++ b/src/services/content.service.ts
@@ -2171,6 +2171,7 @@ export class contentService {
             mechanics_data: {
               $elemMatch: { mechanics_id: mechanics_id, language: language },
             },
+            ...(tags.length > 0 && { tags: { $all: tags } }),
           },
         },
         { $sample: { size: remainingLimit } },


### PR DESCRIPTION
When mechanics_id and tags are both passed, the second fallback query was ignoring the tags filter, allowing content without the requested tag to fill remaining result slots.